### PR TITLE
Fixes for deprecated test subs

### DIFF
--- a/t/edit.t
+++ b/t/edit.t
@@ -34,4 +34,4 @@ for %edits.kv -> $key, $val {
 
 $tl.free();
 
-done;
+done-testing;

--- a/t/error.t
+++ b/t/error.t
@@ -5,10 +5,10 @@ use Audio::Taglib::Simple;
 
 plan 2;
 
-dies_ok({
+dies-ok({
 	Audio::Taglib::Simple.new('non-existent-file.invalid');
 }, 'non-existent file');
 
-dies_ok({
+dies-ok({
 	Audio::Taglib::Simple.new('t/error.t');
 }, 'non-music file');


### PR DESCRIPTION
Hi,
done has become done-testing - without it the tests don't pass anymore.  
Also dies_ok is deprecated in favour of dies-ok and will be going away with the next release.

All good.  I'm using this to test Audio::Encode::LameMP3s ability to write tags into the encoded output.
