### PR TITLE
Keep it up to date

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .*.swp
 t/modified.ogg
+.precomp
+*.rev-deps

--- a/lib/Audio/Taglib/Simple.pm
+++ b/lib/Audio/Taglib/Simple.pm
@@ -10,7 +10,7 @@ my class X::InvalidAudioFile is Exception {
 	}
 }
 
-my constant taglib = 'libtag_c';
+my constant taglib = ('tag_c', v0);
 
 class Audio::Taglib::Simple {
 	has $.file is readonly;


### PR DESCRIPTION
Hi,
The native call now doesn't want the 'lib' prefix as it tries harder to guess the library name, also the version helps to stop a warning.
