### PR TITLE
Drop the "lib" from the library name.

### DIFF
--- a/lib/Audio/Taglib/Simple.pm
+++ b/lib/Audio/Taglib/Simple.pm
@@ -10,7 +10,7 @@ my class X::InvalidAudioFile is Exception {
 	}
 }
 
-my constant taglib = 'libtag_c';
+my constant taglib = 'tag_c';
 
 class Audio::Taglib::Simple {
 	has $.file is readonly;


### PR DESCRIPTION
This is needed for latest Rakudo.
