### PR TITLE
Add Travis-CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+sudo: required
+
+language: perl6
+
+perl6:
+    - latest
+
+install:
+    - sudo apt-get install libtagc0
+    - rakudobrew build-panda
+    - panda installdeps .


### PR DESCRIPTION
This allows the project to be automatically built and tested with the latest version of Perl6 on the [Travis-CI](https://travis-ci.org) continuous integration service.
