### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,6 +1,7 @@
 {
 	"perl" : "6.*",
 	"name" : "Audio::Taglib::Simple",
+	"license" : "MIT",
 	"version" : "0.0.7",
 	"description" : "Read, write ID3 and other audio metadata with TagLib",
 	"author" : "Adrian Kreher",


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license